### PR TITLE
disable object_name_linter

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '291375'
+ValidationKey: '291675'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.lintr
+++ b/.lintr
@@ -1,2 +1,2 @@
-linters: lucode2::lintrRules()
+linters: lucode2::lintrRules(modification = list(object_name_linter = NULL))
 encoding: "UTF-8"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: mredgebuildings
 Title: Prepare data to be used by the EDGE-Buildings model
 Version: 0.1.5
-Date: 2023-03-09
+Date: 2023-03-29
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1818-3186")),

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **mredgebuildings** in publications use:
 
-Hasse R, Führlich P, Levesque A (2023). _mredgebuildings: Prepare data to be used by the EDGE-Buildings model_. R package version 0.1.5, <URL: https://github.com/pik-piam/mredgebuildings>.
+Hasse R, Führlich P, Levesque A (2023). _mredgebuildings: Prepare data to be used by the EDGE-Buildings model_. R package version 0.1.5, <https://github.com/pik-piam/mredgebuildings>.
 
 A BibTeX entry for LaTeX users is
 

--- a/tests/.lintr
+++ b/tests/.lintr
@@ -1,2 +1,2 @@
-linters: lucode2::lintrRules(allowUndesirable = TRUE)
+linters: lucode2::lintrRules(allowUndesirable = TRUE, modification = list(object_name_linter = NULL))
 encoding: "UTF-8"


### PR DESCRIPTION
This removes the linter warning enforcing camelCase.