### PR TITLE
Explicit encoding to avoid Error under Linux

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '409101'
+ValidationKey: '429330'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mredgebuildings: Prepare data to be used by the EDGE-Buildings model'
-version: 0.2.1
-date-released: '2023-05-04'
+version: 0.2.2
+date-released: '2023-06-07'
 abstract: Prepare data to be used by the EDGE-Buildings model.
 authors:
 - family-names: Hasse

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mredgebuildings
 Title: Prepare data to be used by the EDGE-Buildings model
-Version: 0.2.1
-Date: 2023-05-04
+Version: 0.2.2
+Date: 2023-06-07
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1818-3186")),

--- a/R/readEUBuildingsDB.R
+++ b/R/readEUBuildingsDB.R
@@ -31,12 +31,15 @@ readEUBuildingsDB <- function(subtype = "") {
   variable <- strsplit(subtype, ".", fixed = TRUE)[[1]][2]
 
   # available source files
-  files <- list.files()
+  files <- list.files(pattern = "\\.csv$")
   files <- stats::setNames(files, gsub(".csv", "", files))
   file <- toolSubtypeSelect(category, files)
 
   # read csv file and stack regions
-  data <- read.csv(file, skip = 1, header = FALSE)
+  data <- read.csv(file, skip = 1, header = FALSE, encoding = "ISO-8859-1")
+  for (j in 1:2) {
+    data[, j] <- iconv(data[, j], "ISO-8859-1", "ASCII", "byte")
+  }
   startLines <- which(data[, 1] == "") - 1
   data <- do.call("rbind", lapply(seq_along(startLines), function(i) {
     endLine <- ifelse(i == length(startLines),

--- a/R/toolUnitConversion.R
+++ b/R/toolUnitConversion.R
@@ -26,8 +26,6 @@ toolUnitConversion <- function(x, unitConversion, dim = 3.1,
          "'from', 'to', and 'factor'.")
   }
 
-  # convert to ASCII
-  getItems(x, dim) <- iconv(getItems(x, dim), "latin1", "ASCII", "byte")
 
   # all units in data
   units <- unique(gsub("^.*_", "", grep("_", getItems(x, dim), value = TRUE)))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare data to be used by the EDGE-Buildings model
 
-R package **mredgebuildings**, version **0.2.1**
+R package **mredgebuildings**, version **0.2.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mredgebuildings)](https://cran.r-project.org/package=mredgebuildings)  [![R build status](https://github.com/pik-piam/mredgebuildings/workflows/check/badge.svg)](https://github.com/pik-piam/mredgebuildings/actions) [![codecov](https://codecov.io/gh/pik-piam/mredgebuildings/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mredgebuildings) [![r-universe](https://pik-piam.r-universe.dev/badges/mredgebuildings)](https://pik-piam.r-universe.dev/builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **mredgebuildings** in publications use:
 
-Hasse R, Führlich P, Levesque A, Tockhorn H (2023). _mredgebuildings: Prepare data to be used by the EDGE-Buildings model_. R package version 0.2.1, <https://github.com/pik-piam/mredgebuildings>.
+Hasse R, Führlich P, Levesque A, Tockhorn H (2023). _mredgebuildings: Prepare data to be used by the EDGE-Buildings model_. R package version 0.2.2, <https://github.com/pik-piam/mredgebuildings>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {mredgebuildings: Prepare data to be used by the EDGE-Buildings model},
   author = {Robin Hasse and Pascal Führlich and Antoine Levesque and Hagen Tockhorn},
   year = {2023},
-  note = {R package version 0.2.1},
+  note = {R package version 0.2.2},
   url = {https://github.com/pik-piam/mredgebuildings},
 }
 ```

--- a/man/convertDaioglou.Rd
+++ b/man/convertDaioglou.Rd
@@ -9,7 +9,7 @@ convertDaioglou(x, subtype = "households.specific floor space")
 \arguments{
 \item{x}{MAgPIE object with data from Daioglou et al.}
 
-\item{subtype}{<dataFile>.<variable>}
+\item{subtype}{\if{html}{\out{<dataFile>}}.\if{html}{\out{<variable>}}}
 }
 \value{
 clean MAgPIE object with unique data points

--- a/man/convertEUBuildingsDB.Rd
+++ b/man/convertEUBuildingsDB.Rd
@@ -9,7 +9,7 @@ convertEUBuildingsDB(x, subtype)
 \arguments{
 \item{x}{MAgPIE object with data from EU Buildings Database}
 
-\item{subtype}{character <category>.<variable>}
+\item{subtype}{character \if{html}{\out{<category>}}.\if{html}{\out{<variable>}}}
 }
 \value{
 clean MAgPIE object with

--- a/man/convertGDL.Rd
+++ b/man/convertGDL.Rd
@@ -9,7 +9,7 @@ convertGDL(x, subtype)
 \arguments{
 \item{x}{MAgPIE object with data from EU Buildings Database}
 
-\item{subtype}{<database>.<variable>}
+\item{subtype}{\if{html}{\out{<database>}}.\if{html}{\out{<variable>}}}
 }
 \value{
 clean MAgPIE object with data from EU Buildings Database

--- a/man/readDaioglou.Rd
+++ b/man/readDaioglou.Rd
@@ -7,7 +7,7 @@
 readDaioglou(subtype = "households.specific floor space")
 }
 \arguments{
-\item{subtype}{<dataFile>.<variable>}
+\item{subtype}{\if{html}{\out{<dataFile>}}.\if{html}{\out{<variable>}}}
 }
 \description{
 Compilation of survey data. Quintile 0 stands for the entire population.

--- a/man/readEHI.Rd
+++ b/man/readEHI.Rd
@@ -10,7 +10,7 @@ https://www.eurobserv-er.org/
 readEHI(subtype)
 }
 \arguments{
-\item{subtype}{<report series>.<variable>}
+\item{subtype}{\if{html}{\out{<report series>}}.\if{html}{\out{<variable>}}}
 }
 \value{
 magpie object

--- a/man/readEUBuildingsDB.Rd
+++ b/man/readEUBuildingsDB.Rd
@@ -7,7 +7,7 @@
 readEUBuildingsDB(subtype = "")
 }
 \arguments{
-\item{subtype}{character <category>.<variable>}
+\item{subtype}{character \if{html}{\out{<category>}}.\if{html}{\out{<variable>}}}
 }
 \value{
 magpie object

--- a/man/readEurObservER.Rd
+++ b/man/readEurObservER.Rd
@@ -10,7 +10,7 @@ https://www.eurobserv-er.org/
 readEurObservER(subtype)
 }
 \arguments{
-\item{subtype}{<report series>.<variable>}
+\item{subtype}{\if{html}{\out{<report series>}}.\if{html}{\out{<variable>}}}
 }
 \value{
 magpie object

--- a/man/readGDL.Rd
+++ b/man/readGDL.Rd
@@ -10,7 +10,7 @@ https://globaldatalab.org/
 readGDL(subtype)
 }
 \arguments{
-\item{subtype}{<database>.<variable>}
+\item{subtype}{\if{html}{\out{<database>}}.\if{html}{\out{<variable>}}}
 }
 \value{
 magpie object


### PR DESCRIPTION
Reading EUBuildingsDB files failed on Linux due to different encoding. This is now explicitly defined.