### PR TITLE
Adjust to upstream changes in mrdrivers and mrremind

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1502400'
+ValidationKey: '1523192'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1523192'
+ValidationKey: '1523420'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mredgebuildings: Prepare data to be used by the EDGE-Buildings model'
-version: 0.7.5
-date-released: '2024-11-05'
+version: 0.7.6
+date-released: '2024-11-15'
 abstract: Prepare data to be used by the EDGE-Buildings model.
 authors:
 - family-names: Hasse

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'mredgebuildings: Prepare data to be used by the EDGE-Buildings model'
 version: 0.7.6
-date-released: '2024-11-15'
+date-released: '2024-11-18'
 abstract: Prepare data to be used by the EDGE-Buildings model.
 authors:
 - family-names: Hasse

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: mredgebuildings
 Title: Prepare data to be used by the EDGE-Buildings model
 Version: 0.7.6
-Date: 2024-11-15
+Date: 2024-11-18
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1818-3186")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mredgebuildings
 Title: Prepare data to be used by the EDGE-Buildings model
-Version: 0.7.5
-Date: 2024-11-05
+Version: 0.7.6
+Date: 2024-11-15
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1818-3186")),

--- a/R/calcFEUEefficiencies.R
+++ b/R/calcFEUEefficiencies.R
@@ -137,7 +137,10 @@ calcFEUEefficiencies <- function(gasBioEquality = TRUE) {
         mutate(variable = eqEffs[gasVar][[1]]) %>%
         separate("variable", into = c("enduse", "carrier"), sep = "\\.")
 
-      efficiencies <- rbind(efficiencies, bioEffs)
+      efficiencies <- rbind(
+        anti_join(efficiencies, bioEffs, by = c("region", "period", "enduse", "carrier", "scenario")),
+        bioEffs
+      )
     }
   }
 

--- a/R/calcFloorspacePast.R
+++ b/R/calcFloorspacePast.R
@@ -139,13 +139,17 @@ calcFloorspacePast <- function() {
            region = "IND")
 
   # historic population
-  pop <- calcOutput("PopulationPast", aggregate = FALSE) %>%
+  pop <- calcOutput("Population", scenario = "SSP2", aggregate = FALSE) %>%
     as.quitte() %>%
-    mutate(unit = "million cap")
+    filter(.data[["period"]] <= endOfHistory) %>%
+    mutate(unit = "million cap",
+           variable = gsub("pop_SSP2", "population", .data[["variable"]], fixed = TRUE))
 
   # historic GDP per capita
-  gdppop <- calcOutput("GDPPast", aggregate = FALSE) %>% # nolint
+  gdppop <- calcOutput("GDP", scenario = "SSP2", average2020 = FALSE, aggregate = FALSE, unit = "constant 2005 Int$PPP") %>% # nolint
     as.quitte() %>%
+    filter(.data[["period"]] <= endOfHistory) %>%
+    mutate(variable = gsub("gdp_SSP2", "gdp in constant 2005 Int$PPP", .data[["variable"]], fixed = TRUE)) %>%
     rbind(pop) %>%
     calc_addVariable(gdppop = "`gdp in constant 2005 Int$PPP` / `population`",
                      units = "USD2005/cap", only.new = TRUE) %>%

--- a/R/calcFloorspacePast.R
+++ b/R/calcFloorspacePast.R
@@ -153,7 +153,8 @@ calcFloorspacePast <- function() {
 
   # share of urban population
   urbanshare <- calcOutput("UrbanPast", aggregate = FALSE) %>%
-    as.quitte()
+    as.quitte() %>%
+    mutate(variable = "urbanPop")
 
   # population density
   dens <- calcOutput("Density", aggregate = FALSE) %>%

--- a/R/calcShareETP.R
+++ b/R/calcShareETP.R
@@ -75,18 +75,17 @@ calcShareETP <- function(subtype = c("enduse", "carrier"), feOnly = FALSE) {
   etpFilter <- etp %>%
     as.quitte() %>%
     filter(.data[["period"]] %in% periods,
-           .data[["data"]] %in% scen) %>%
-    filter(.data[["data1"]] %in% names(reval),
+           .data[["scenario"]] %in% scen) %>%
+    filter(.data[["variable"]] %in% names(reval),
            !is.na(.data[["value"]])) %>%
-    mutate(data1 = droplevels(revalue(.data[["data1"]], reval)))
+    mutate(variable = droplevels(revalue(.data[["variable"]], reval)))
 
-  names(etpFilter)[names(etpFilter) == "data1"] <- shareOf
+  names(etpFilter)[names(etpFilter) == "variable"] <- shareOf
 
 
   # Extrapolate 'biotrad' share from 'biomod' values for carrier separation
   if (subtype == "carrier") {
     etpFilter <- etpFilter %>%
-      select(-"variable") %>%
       rename(variable = "carrier") %>%
       toolSplitBiomass(gdppop, varName = "biomod") %>%
       rename(carrier = "variable")
@@ -114,7 +113,7 @@ calcShareETP <- function(subtype = c("enduse", "carrier"), feOnly = FALSE) {
 
     # Local Shares
     share <- etpFilter %>%
-      select(-"data", -"data2", -"unit", -"model", -"scenario") %>%
+      select(-"unit", -"model", -"scenario") %>%
       group_by(across(all_of(c("region", "period", shareOf)))) %>%
       summarise(value = sum(.data[["value"]]), .groups = "drop") %>%
       ungroup() %>%
@@ -195,7 +194,8 @@ calcShareETP <- function(subtype = c("enduse", "carrier"), feOnly = FALSE) {
       mutate(value = .data[["value"]] * PJ2EJ,
              unit = "EJ") %>%
       select("region", "period", "unit", shareOf, "value") %>%
-      as.magpie()
+      as.magpie() %>%
+      toolCountryFill(verbosity = 0)
 
     return(list(x = feData,
                 unit = "EJ/yr",
@@ -209,6 +209,7 @@ calcShareETP <- function(subtype = c("enduse", "carrier"), feOnly = FALSE) {
     droplevels() %>%
     as.magpie(spatial = 1) %>%
     toolCountryFill(verbosity = 0)
+
 
   regShare <- regShare %>%
     as.magpie(spatial = 1) %>%

--- a/R/calcShareETP.R
+++ b/R/calcShareETP.R
@@ -210,7 +210,6 @@ calcShareETP <- function(subtype = c("enduse", "carrier"), feOnly = FALSE) {
     as.magpie(spatial = 1) %>%
     toolCountryFill(verbosity = 0)
 
-
   regShare <- regShare %>%
     as.magpie(spatial = 1) %>%
     collapseDim() %>%

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare data to be used by the EDGE-Buildings model
 
-R package **mredgebuildings**, version **0.7.5**
+R package **mredgebuildings**, version **0.7.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mredgebuildings)](https://cran.r-project.org/package=mredgebuildings)  [![R build status](https://github.com/pik-piam/mredgebuildings/workflows/check/badge.svg)](https://github.com/pik-piam/mredgebuildings/actions) [![codecov](https://codecov.io/gh/pik-piam/mredgebuildings/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mredgebuildings) [![r-universe](https://pik-piam.r-universe.dev/badges/mredgebuildings)](https://pik-piam.r-universe.dev/builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **mredgebuildings** in publications use:
 
-Hasse R, Führlich P, Levesque A, Tockhorn H (2024). _mredgebuildings: Prepare data to be used by the EDGE-Buildings model_. R package version 0.7.5, <https://github.com/pik-piam/mredgebuildings>.
+Hasse R, Führlich P, Levesque A, Tockhorn H (2024). _mredgebuildings: Prepare data to be used by the EDGE-Buildings model_. R package version 0.7.6, <https://github.com/pik-piam/mredgebuildings>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {mredgebuildings: Prepare data to be used by the EDGE-Buildings model},
   author = {Robin Hasse and Pascal Führlich and Antoine Levesque and Hagen Tockhorn},
   year = {2024},
-  note = {R package version 0.7.5},
+  note = {R package version 0.7.6},
   url = {https://github.com/pik-piam/mredgebuildings},
 }
 ```


### PR DESCRIPTION
Includes changes to make mredgebuildings runnable again after upstream changes:
- Adjust variable name in UrbanPast to new variable name from mrdrivers output
- adjust column names in ShareEtp to refactoring of readIEA_ETP
- Switch from GDPPast and PopulationPast to GDP and Population in FloorspacePast
- avoid duplicate entries in FEUEefficiencies