### PR TITLE
Fix bug in calcShareOdyssee

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2176487'
+ValidationKey: '2197692'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mredgebuildings: Prepare data to be used by the EDGE-Buildings model'
-version: 0.10.7
-date-released: '2025-09-10'
+version: 0.10.8
+date-released: '2025-09-18'
 abstract: Prepare data to be used by the EDGE-Buildings model.
 authors:
 - family-names: Hasse

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mredgebuildings
 Title: Prepare data to be used by the EDGE-Buildings model
-Version: 0.10.7
-Date: 2025-09-10
+Version: 0.10.8
+Date: 2025-09-18
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1818-3186")),

--- a/R/calcShareOdyssee.R
+++ b/R/calcShareOdyssee.R
@@ -33,10 +33,10 @@ calcShareOdyssee <- function(subtype = c("enduse", "carrier", "enduse_carrier"),
   # READ-IN DATA ---------------------------------------------------------------
 
   # Read Buildings Data
-  odysseeData <- rbind(readSource("Odyssee", subtype = "090125") %>%
+  odysseeData <- rbind(readSource("Odyssee", subtype = "250109") %>%
                          as.quitte() %>%
                          mutate(version = "new"),
-                       readSource("Odyssee", subtype = "050422") %>%
+                       readSource("Odyssee", subtype = "220405") %>%
                          as.quitte() %>%
                          mutate(version = "old"))
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare data to be used by the EDGE-Buildings model
 
-R package **mredgebuildings**, version **0.10.7**
+R package **mredgebuildings**, version **0.10.8**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mredgebuildings)](https://cran.r-project.org/package=mredgebuildings) [![R build status](https://github.com/pik-piam/mredgebuildings/workflows/check/badge.svg)](https://github.com/pik-piam/mredgebuildings/actions) [![codecov](https://codecov.io/gh/pik-piam/mredgebuildings/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mredgebuildings) [![r-universe](https://pik-piam.r-universe.dev/badges/mredgebuildings)](https://pik-piam.r-universe.dev/builds)
 
@@ -38,17 +38,15 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **mredgebuildings** in publications use:
 
-Hasse R, Sauer P, Levesque A, Tockhorn H (2025). "mredgebuildings: Prepare data to be used by the EDGE-Buildings model." Version: 0.10.7, <https://github.com/pik-piam/mredgebuildings>.
+Hasse R, Sauer P, Levesque A, Tockhorn H (2025). "mredgebuildings: Prepare data to be used by the EDGE-Buildings model - Version 0.10.8."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {mredgebuildings: Prepare data to be used by the EDGE-Buildings model},
+  title = {mredgebuildings: Prepare data to be used by the EDGE-Buildings model - Version 0.10.8},
   author = {Robin Hasse and Pascal Sauer and Antoine Levesque and Hagen Tockhorn},
-  date = {2025-09-10},
+  date = {2025-09-18},
   year = {2025},
-  url = {https://github.com/pik-piam/mredgebuildings},
-  note = {Version: 0.10.7},
 }
 ```


### PR DESCRIPTION
Subtypes called in ```calcShareOdyssee``` were still named by ```DDMMYY``` which was inconsistent with ```read/convertOdyssee```.
This PR fixes that.