### PR TITLE
Fix bug in standing lifetime computation

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2197692'
+ValidationKey: '2218477'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mredgebuildings: Prepare data to be used by the EDGE-Buildings model'
-version: 0.10.8
-date-released: '2025-09-18'
+version: 0.10.9
+date-released: '2025-09-22'
 abstract: Prepare data to be used by the EDGE-Buildings model.
 authors:
 - family-names: Hasse

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mredgebuildings
 Title: Prepare data to be used by the EDGE-Buildings model
-Version: 0.10.8
-Date: 2025-09-18
+Version: 0.10.9
+Date: 2025-09-22
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1818-3186")),

--- a/R/calcLifetimeParams.R
+++ b/R/calcLifetimeParams.R
@@ -71,16 +71,17 @@ calcLifetimeParams <- function(subtype, granularity = NULL) {
   calcStandingLt <- function(x, factors = NULL) {
     scale <- mselect(x, variable = "scale", collapseNames = TRUE)
     shape <- mselect(x, variable = "shape", collapseNames = TRUE)
-
-    nm <- "standingLt"
-    x <- add_columns(x, addnm = nm, dim = "variable")
-    x[, , nm] <- scale * gamma(2 / shape) / gamma(1 / shape)
+    mFactors <- new.magpie(names = getNames(scale), fill = 1, sets = getSets(scale))
 
     if (!is.null(factors)) {
       for (item in names(factors)) {
-        x[, , paste(item, nm, sep = ".")] <- x[, , paste(item, nm, sep = ".")] * factors[[item]]
+        mFactors[, , item] <- factors[[item]]
       }
     }
+
+    nm <- "standingLt"
+    x <- add_columns(x, addnm = nm, dim = "variable")
+    x[, , nm] <- scale * gamma(2 / shape) / gamma(1 / shape) * mFactors
 
     x
   }

--- a/R/calcLifetimeParams.R
+++ b/R/calcLifetimeParams.R
@@ -78,7 +78,7 @@ calcLifetimeParams <- function(subtype, granularity = NULL) {
 
     if (!is.null(factors)) {
       for (item in names(factors)) {
-        x[, , item] <- x[, , item] * factors[[item]]
+        x[, , paste(item, nm, sep = ".")] <- x[, , paste(item, nm, sep = ".")] * factors[[item]]
       }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare data to be used by the EDGE-Buildings model
 
-R package **mredgebuildings**, version **0.10.8**
+R package **mredgebuildings**, version **0.10.9**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mredgebuildings)](https://cran.r-project.org/package=mredgebuildings) [![R build status](https://github.com/pik-piam/mredgebuildings/workflows/check/badge.svg)](https://github.com/pik-piam/mredgebuildings/actions) [![codecov](https://codecov.io/gh/pik-piam/mredgebuildings/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mredgebuildings) [![r-universe](https://pik-piam.r-universe.dev/badges/mredgebuildings)](https://pik-piam.r-universe.dev/builds)
 
@@ -38,15 +38,15 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **mredgebuildings** in publications use:
 
-Hasse R, Sauer P, Levesque A, Tockhorn H (2025). "mredgebuildings: Prepare data to be used by the EDGE-Buildings model - Version 0.10.8."
+Hasse R, Sauer P, Levesque A, Tockhorn H (2025). "mredgebuildings: Prepare data to be used by the EDGE-Buildings model - Version 0.10.9."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {mredgebuildings: Prepare data to be used by the EDGE-Buildings model - Version 0.10.8},
+  title = {mredgebuildings: Prepare data to be used by the EDGE-Buildings model - Version 0.10.9},
   author = {Robin Hasse and Pascal Sauer and Antoine Levesque and Hagen Tockhorn},
-  date = {2025-09-18},
+  date = {2025-09-22},
   year = {2025},
 }
 ```


### PR DESCRIPTION
So far, the additional factor in the standing lifetime computation did not only apply to the standing lifetime, but to all parameters in the lifetime object, so also to the shape and scale parameters. This is now fixed.