### PR TITLE
Integrate ICT demand projections until 2100

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3183700'
+ValidationKey: '3204708'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mredgebuildings: Prepare data to be used by the EDGE-Buildings model'
-version: 0.15.5
-date-released: '2026-03-28'
+version: 0.15.6
+date-released: '2026-03-31'
 abstract: Prepare data to be used by the EDGE-Buildings model.
 authors:
 - family-names: Hasse

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mredgebuildings
 Title: Prepare data to be used by the EDGE-Buildings model
-Version: 0.15.5
-Date: 2026-03-28
+Version: 0.15.6
+Date: 2026-03-31
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1818-3186")),

--- a/R/calcElecDemandICT.R
+++ b/R/calcElecDemandICT.R
@@ -17,8 +17,6 @@
 #' data (IEA Base) is separated and harmonized with SSP scenario projections.
 #'
 #' @param endOfHistory upper temporal boundary for historical data
-#' @param extrapolate if \code{TRUE}, regional demand will be linearly extrapolated using the slope
-#' of the last two existing data points per scenario, if \code{FALSE} data remains unchanged
 #'
 #' @returns A magpie object containing ICT electricity demand data calculated from
 #'   DC demands across regions, time periods, and scenarios.
@@ -35,7 +33,7 @@
 #' @importFrom magclass as.magpie
 #' @importFrom madrat toolCountryFill
 
-calcElecDemandICT <- function(endOfHistory = 2025, extrapolate = FALSE) {
+calcElecDemandICT <- function(endOfHistory = 2025) {
 
   # PARAMETER ------------------------------------------------------------------
 
@@ -52,7 +50,7 @@ calcElecDemandICT <- function(endOfHistory = 2025, extrapolate = FALSE) {
     filter(!is.na(.data$value))
 
   # R5 Resolution (Elec. Demand DC)
-  dataR5 <- readSource("PRISMA_ICT", subtype = "R5", convert = FALSE) %>%
+  dataR5 <- readSource("PRISMA_ICT", subtype = "R5 2100", convert = FALSE) %>%
     as_tibble() %>%
     filter(!is.na(.data$value))
 
@@ -93,7 +91,8 @@ calcElecDemandICT <- function(endOfHistory = 2025, extrapolate = FALSE) {
     reframe(value = sum(.data$value)) %>%
     ungroup() %>%
     pivot_wider(names_from = "variable", values_from = "value") %>%
-    mutate(ratio = .data$ict / .data$dc - 1, .keep = "unused")
+    mutate(ratio = .data$ict / .data$dc - 1, .keep = "unused") %>%
+    interpolate_missing_periods(unique(dataR5$period), expand.values = TRUE, value = "ratio")
 
 
   data <- dataR5 %>%
@@ -137,7 +136,7 @@ calcElecDemandICT <- function(endOfHistory = 2025, extrapolate = FALSE) {
     ungroup() %>%
     select(-"regionTarget", -"weight") %>%
 
-    # calculate ICT (DC + Network) demand using global network share
+    # calculate ICT (DC + Network) demand using global network / DC ratio
     left_join(networkDCRatio, by = c("estimate", "period")) %>%
     mutate(value = .data$value * (1 + .data$ratio), .keep = "unused") %>%
     select(-"variable", -"unit") %>%
@@ -148,33 +147,6 @@ calcElecDemandICT <- function(endOfHistory = 2025, extrapolate = FALSE) {
            carrier = "elec",
            enduse = "ict") %>%
     replace_na(list("value" = 0))
-
-
-  # extrapolate scenario data to 2100 using linear fit over last two periods (here: 2045-50)
-  if (isTRUE(extrapolate)) {
-    data <- data %>%
-      group_by(across(all_of(c("region", "scenario", "variable")))) %>%
-      group_modify(~ {
-        periods <- sort(unique(.x$period))
-
-        if (.y$scenario != "history") {
-          # linear extrapolation for future scenarios
-          fitData <- .x %>%
-            filter(.data$period %in% tail(periods, 2))
-
-          model <- lm(value ~ period, data = fitData)
-
-          .x %>%
-            interpolate_missing_periods(seq.int(endOfHistory + 5, 2100, 5)) %>%
-            mutate(pred = predict(model, newdata = .),
-                   value = ifelse(is.na(.data$value), pmax(0, .data$pred), .data$value)) %>%
-            select(-"pred")
-        } else {
-          .x
-        }
-      }) %>%
-      ungroup()
-  }
 
 
 

--- a/R/calcElecDemandICT.R
+++ b/R/calcElecDemandICT.R
@@ -150,18 +150,6 @@ calcElecDemandICT <- function(endOfHistory = 2025) {
 
 
 
-  # weights
-  weights <- dataDC %>%
-    select("region", "value") %>%
-    mutate(region = as.character(.data$region)) %>%
-    right_join(data %>%
-                 select("region", "period", "variable") %>%
-                 unique(),
-               by = "region") %>%
-    replace_na(list("value" = 0))
-
-
-
   # OUTPUT ---------------------------------------------------------------------
 
   data <- data %>%
@@ -169,14 +157,8 @@ calcElecDemandICT <- function(endOfHistory = 2025) {
     as.magpie() %>%
     toolCountryFill(0, verbosity = 2)
 
-  weights <- weights %>%
-    as.quitte() %>%
-    as.magpie() %>%
-    toolCountryFill(0, verbosity = 2)
-
 
   return(list(x = data,
-              weight = weights,
               unit = "EJ",
               min = 0,
               description = "Annual historical and SSP ICT electricity demands"))

--- a/R/calcElecDemandICT.R
+++ b/R/calcElecDemandICT.R
@@ -7,7 +7,7 @@
 #'
 #' The function processes multiple demand estimates:
 #' \itemize{
-#'   \item Mean and central estimate
+#'   \item Mean and medium estimate
 #'   \item Lower demand boundary (DGI elasticity from historical efficiency dominant phases)
 #'   \item Upper demand boundary (DGI elasticity from historical service dominant phases)
 #' }

--- a/R/calcElecDemandICT.R
+++ b/R/calcElecDemandICT.R
@@ -12,9 +12,10 @@
 #'   \item Upper demand boundary (DGI elasticity from historical service dominant phases)
 #' }
 #'
-#' Data is downscaled from R5 to country-level using historical DC counts,
-#' with fixed network shares calculated at the end of the historical period. Historical
-#' data (IEA Base) is separated and harmonized with SSP scenario projections.
+#' Data is downscaled from R5 to country-level using data center counts as weights,
+#' with exceptional fixed shares for China within Asia Pacific (73.28%) and for Europe's
+#' R12 sub-regions (WEU: 75%, EEU: 14%, FSU: 11%). Network demand is added using global network/DC ratios.
+#' Historical data (IEA Base) is separated and harmonized with SSP scenario projections.
 #'
 #' @param endOfHistory upper temporal boundary for historical data
 #'
@@ -40,6 +41,14 @@ calcElecDemandICT <- function(endOfHistory = 2025) {
   # TWh to EJ conversion factor
   twh2ej <- 3600 * 10^12 / 10^18
 
+  # fixed share of ICT demand China <-> Asia Pacific
+  chinaShare <- 0.7328
+
+  # fixed shares of R12 regions within R5 Europe
+  europeShares <- data.frame(
+    "R12" = c("WEU", "EEU", "FSU"),
+    "share" = c(0.75, 0.14, 0.11)
+  )
 
 
   # READ-IN DATA ---------------------------------------------------------------
@@ -60,10 +69,16 @@ calcElecDemandICT <- function(endOfHistory = 2025) {
     filter(!is.na(.data$value))
 
 
+  # MessageIX region mapping
+  regionmapMessage <- toolGetMapping("regionmappingMessageIX.csv",
+                                     type = "regional",
+                                     where = "mredgebuildings")
+
   # IEA R5 region mapping
-  regionmap <- toolGetMapping("regionmappingIEA_R5.csv",
-                              type = "regional",
-                              where = "mredgebuildings")
+  regionmapR5 <- toolGetMapping("regionmappingIEA_R5.csv",
+                                type = "regional",
+                                where = "mredgebuildings")
+
 
   # variable mapping
   variableMap <- toolGetMapping("variableMapping_ICT.csv",
@@ -74,6 +89,14 @@ calcElecDemandICT <- function(endOfHistory = 2025) {
 
 
   # PROCESS DATA ---------------------------------------------------------------
+
+  # unite region mappings (ISO -> R5 -> R12)
+  regionmap <- regionmapR5 %>%
+    select("region" = "CountryCode", "R5" = "Region") %>%
+    left_join(regionmapMessage %>%
+                select("region" = "CountryCode", "R12"),
+              by = "region")
+
 
   # re-map variables in R5 and R12
   dataR12 <- dataR12 %>%
@@ -119,13 +142,38 @@ calcElecDemandICT <- function(endOfHistory = 2025) {
         ieaScenarioExpanded
       )
     })() %>%
+    rename("R5" = "region") %>%
+    left_join(regionmap, by = "R5", relationship = "many-to-many") %>%
 
-    # add country-level weights (number of DCs)
-    rename("regionTarget" = "region") %>%
-    left_join(regionmap %>%
-                select("region" = "CountryCode", "regionTarget" = "Region"),
-              by = "regionTarget",
-              relationship = "many-to-many") %>%
+    # Step 1: Disaggregate regions with fixed disaggregation shares (China + Europe)
+    (\(df) {
+      # disaggregate China from Asia Pacific with fixed share
+      chinaDisagg <- df %>%
+        filter(.data$R5 == "Asia Pacific") %>%
+        mutate(share = ifelse(.data$region == "CHN", chinaShare, 1 - chinaShare),
+               value = .data$value * .data$share,
+               regionTarget = ifelse(.data$region == "CHN", "CHN", .data$R5)) %>%
+        select(-"share", -"R5", -"R12")
+
+      # disaggregate Europe into R12 regions with fixed shares
+      europeDisagg <- df %>%
+        filter(.data$R5 == "Europe") %>%
+        left_join(europeShares, by = "R12") %>%
+        mutate(value = .data$value * .data$share,
+               regionTarget = .data$R12) %>%
+        select(-"share", -"R5", -"R12")
+
+      # filter remaining regions
+      rest <- df %>%
+        filter(!.data$R5 %in% c("Asia Pacific", "Europe")) %>%
+        mutate(regionTarget = .data$R5) %>%
+        select(-"R5", -"R12")
+
+      # bind all data
+      rbind(chinaDisagg, europeDisagg, rest)
+    })() %>%
+
+    # Step 2: Disaggregate within each regionTarget using DC counts
     left_join(dataDC %>%
                 select("region", "weight" = "value"),
               by = "region") %>%

--- a/R/calcElecDemandICT.R
+++ b/R/calcElecDemandICT.R
@@ -54,17 +54,17 @@ calcElecDemandICT <- function(endOfHistory = 2025) {
   # READ-IN DATA ---------------------------------------------------------------
 
   # R12 Resolution (Elec. Demand DC + ICT)
-  dataR12 <- readSource("PRISMA_ICT", subtype = "R12", convert = FALSE) %>%
+  dataR12 <- readSource("PRISMA_ICT", subtype = "Output_R12", convert = FALSE) %>%
     as_tibble() %>%
     filter(!is.na(.data$value))
 
   # R5 Resolution (Elec. Demand DC)
-  dataR5 <- readSource("PRISMA_ICT", subtype = "R5 2100", convert = FALSE) %>%
+  dataR5 <- readSource("PRISMA_ICT", subtype = "R5 DC_2100_revised", convert = FALSE) %>%
     as_tibble() %>%
     filter(!is.na(.data$value))
 
   # Number of DCs
-  dataDC <- readSource("PRISMA_ICT", subtype = "nDC") %>%
+  dataDC <- readSource("PRISMA_ICT", subtype = "Num. DC") %>%
     as_tibble() %>%
     filter(!is.na(.data$value))
 

--- a/R/convertPRISMA_ICT.R
+++ b/R/convertPRISMA_ICT.R
@@ -15,7 +15,7 @@
 #'
 convertPRISMA_ICT <- function(x, subtype) { # nolint: object_name_linter
 
-  if (subtype == "nDC") {
+  if (subtype == "Num. DC") {
     getItems(x, 1) <- toolCountry2isocode(getItems(x, 1))
     x <- toolCountryFill(x, verbosity = 2)
   }

--- a/R/readPRISMA_ICT.R
+++ b/R/readPRISMA_ICT.R
@@ -4,7 +4,7 @@
 #' Supports different regional resolutions and data center counts.
 #'
 #' @param subtype Character string specifying data type: "R12" for 12-region ICT data,
-#'   "R5" for 5-region data center data, or "nDC" for data center counts
+#'   "R5" for 5-region data center data ("R5 2100" until 2100), or "nDC" for data center counts
 #'
 #' @returns A magpie object containing the requested ICT/data center data
 #'
@@ -19,14 +19,15 @@
 readPRISMA_ICT <- function(subtype) { # nolint: object_name_linter
 
   subtype <- switch(subtype,
+                    "R5 2100" = "R5 DC_2100",
                     "R12" = "Output_R12",
                     "R5"  = "R5 DC",
                     "nDC" = "Num. DC",
                     subtype)
 
-  fileName <- "R12_Clean IAM  Version_Finalised.xlsx"
+  fileName <- "R12_Clean IAM Version_Finalised_2100.xlsx"
 
-  if (subtype %in% c("Output_R12", "R5 DC")) {
+  if (subtype %in% c("Output_R12", "R5 DC", "R5 DC_2100")) {
     # Read and process energy data sheets
     data <- read.xlsx(fileName, sheet = subtype, check.names = FALSE, sep.names = " ") %>%
       (\(df) setNames(df, gsub(" \\(twh\\)", "", tolower(names(df)))))() %>%

--- a/R/readPRISMA_ICT.R
+++ b/R/readPRISMA_ICT.R
@@ -3,8 +3,7 @@
 #' Reads ICT and data center electricity demand data from PRISMA project Excel file.
 #' Supports different regional resolutions and data center counts.
 #'
-#' @param subtype Character string specifying data type: "R12" for 12-region ICT data,
-#'   "R5" for 5-region data center data ("R5 2100" until 2100), or "nDC" for data center counts
+#' @param subtype Character string specifying data type
 #'
 #' @returns A magpie object containing the requested ICT/data center data
 #'
@@ -18,16 +17,9 @@
 #'
 readPRISMA_ICT <- function(subtype) { # nolint: object_name_linter
 
-  subtype <- switch(subtype,
-                    "R5 2100" = "R5 DC_2100",
-                    "R12" = "Output_R12",
-                    "R5"  = "R5 DC",
-                    "nDC" = "Num. DC",
-                    subtype)
+  fileName <- "R12_Clean IAM Version_Finalised_2100_update_2026-03-31.xlsx"
 
-  fileName <- "R12_Clean IAM Version_Finalised_2100.xlsx"
-
-  if (subtype %in% c("Output_R12", "R5 DC", "R5 DC_2100")) {
+  if (subtype %in% c("Output_R12", "R5 DC", "R5 DC_2100_revised")) {
     # Read and process energy data sheets
     data <- read.xlsx(fileName, sheet = subtype, check.names = FALSE, sep.names = " ") %>%
       (\(df) setNames(df, gsub(" \\(twh\\)", "", tolower(names(df)))))() %>%

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare data to be used by the EDGE-Buildings model
 
-R package **mredgebuildings**, version **0.15.5**
+R package **mredgebuildings**, version **0.15.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mredgebuildings)](https://cran.r-project.org/package=mredgebuildings) [![R build status](https://github.com/pik-piam/mredgebuildings/workflows/check/badge.svg)](https://github.com/pik-piam/mredgebuildings/actions) [![codecov](https://codecov.io/gh/pik-piam/mredgebuildings/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mredgebuildings) [![r-universe](https://pik-piam.r-universe.dev/badges/mredgebuildings)](https://pik-piam.r-universe.dev/builds)
 
@@ -38,15 +38,15 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **mredgebuildings** in publications use:
 
-Hasse R, Sauer P, Levesque A, Tockhorn H (2026). "mredgebuildings: Prepare data to be used by the EDGE-Buildings model - Version 0.15.5."
+Hasse R, Sauer P, Levesque A, Tockhorn H (2026). "mredgebuildings: Prepare data to be used by the EDGE-Buildings model - Version 0.15.6."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {mredgebuildings: Prepare data to be used by the EDGE-Buildings model - Version 0.15.5},
+  title = {mredgebuildings: Prepare data to be used by the EDGE-Buildings model - Version 0.15.6},
   author = {Robin Hasse and Pascal Sauer and Antoine Levesque and Hagen Tockhorn},
-  date = {2026-03-28},
+  date = {2026-03-31},
   year = {2026},
 }
 ```

--- a/inst/extdata/regional/regionmappingIEA_R5.csv
+++ b/inst/extdata/regional/regionmappingIEA_R5.csv
@@ -11,7 +11,7 @@ Argentina,ARG,Latin America
 Armenia,ARM,Europe
 American Samoa,ASM,Asia Pacific
 Antarctica,ATA,Latin America
-French Southern Territories,ATF,Asia Pacific
+French Southern Territories,ATF,Latin America
 Antigua and Barbuda,ATG,Latin America
 Australia,AUS,Asia Pacific
 Austria,AUT,Europe
@@ -73,7 +73,7 @@ Estonia,EST,Europe
 Ethiopia,ETH,Middle East and Africa
 Finland,FIN,Europe
 Fiji,FJI,Asia Pacific
-Falkland Islands,FLK,Europe
+Falkland Islands,FLK,Latin America
 France,FRA,Europe
 Faroe Islands,FRO,Europe
 Micronesia,FSM,Asia Pacific
@@ -96,7 +96,7 @@ French Guiana,GUF,Latin America
 Guam,GUM,Asia Pacific
 Guyana,GUY,Latin America
 Hong Kong,HKG,Asia Pacific
-Heard Island and McDonald Islands,HMD,Europe
+Heard Island and McDonald Islands,HMD,Asia Pacific
 Honduras,HND,Latin America
 Croatia,HRV,Europe
 Haiti,HTI,Latin America
@@ -104,7 +104,7 @@ Hungary,HUN,Europe
 Indonesia,IDN,Asia Pacific
 Isle of Man,IMN,Europe
 India,IND,Asia Pacific
-British Indian Ocean Territory,IOT,Asia Pacific
+British Indian Ocean Territory,IOT,Middle East and Africa
 Ireland,IRL,Europe
 Iran,IRN,Middle East and Africa
 Iraq,IRQ,Middle East and Africa
@@ -157,7 +157,7 @@ Martinique,MTQ,Latin America
 Mauritius,MUS,Middle East and Africa
 Malawi,MWI,Middle East and Africa
 Malaysia,MYS,Asia Pacific
-Mayotte,MYT,Asia Pacific
+Mayotte,MYT,Middle East and Africa
 Namibia,NAM,Middle East and Africa
 New Caledonia,NCL,Asia Pacific
 Niger,NER,Middle East and Africa
@@ -179,7 +179,7 @@ Philippines,PHL,Asia Pacific
 Palau,PLW,Asia Pacific
 Papua New Guinea,PNG,Asia Pacific
 Poland,POL,Europe
-Puerto Rico,PRI,Europe
+Puerto Rico,PRI,North America
 North Korea,PRK,Asia Pacific
 Portugal,PRT,Europe
 Paraguay,PRY,Latin America
@@ -195,14 +195,14 @@ Sudan,SDN,Middle East and Africa
 Senegal,SEN,Middle East and Africa
 Singapore,SGP,Asia Pacific
 South Georgia and South Sandwich Islands,SGS,Latin America
-Saint Helena,SHN,Europe
+Saint Helena,SHN,Middle East and Africa
 Svalbard and Jan Mayen,SJM,Europe
 Solomon Islands,SLB,Asia Pacific
 Sierra Leone,SLE,Middle East and Africa
 El Salvador,SLV,Latin America
 San Marino,SMR,Europe
 Somalia,SOM,Middle East and Africa
-Saint Pierre and Miquelon,SPM,Europe
+Saint Pierre and Miquelon,SPM,North America
 Serbia,SRB,Europe
 South Sudan,SSD,Middle East and Africa
 Sao Tome and Principe,STP,Middle East and Africa
@@ -212,9 +212,9 @@ Slovenia,SVN,Europe
 Sweden,SWE,Europe
 Eswatini,SWZ,Middle East and Africa
 Sint Maarten,SXM,Latin America
-Seychelles,SYC,Asia Pacific
+Seychelles,SYC,Middle East and Africa
 Syrian Arab Republic,SYR,Middle East and Africa
-Turks and Caicos Islands,TCA,Europe
+Turks and Caicos Islands,TCA,Latin America
 Chad,TCD,Middle East and Africa
 Togo,TGO,Middle East and Africa
 Thailand,THA,Asia Pacific
@@ -238,11 +238,11 @@ Uzbekistan,UZB,Europe
 Vatican City,VAT,Europe
 Saint Vincent and the Grenadines,VCT,Latin America
 Venezuela,VEN,Latin America
-British Virgin Islands,VGB,Europe
-US Virgin Islands,VIR,Europe
+British Virgin Islands,VGB,Latin America
+US Virgin Islands,VIR,Latin America
 Viet Nam,VNM,Asia Pacific
 Vanuatu,VUT,Asia Pacific
-Wallis and Futuna,WLF,Europe
+Wallis and Futuna,WLF,Asia Pacific
 Samoa,WSM,Asia Pacific
 Yemen,YEM,Middle East and Africa
 South Africa,ZAF,Middle East and Africa

--- a/inst/extdata/regional/regionmappingMessageIX.csv
+++ b/inst/extdata/regional/regionmappingMessageIX.csv
@@ -1,252 +1,252 @@
-X;CountryCode;11regions;5regions;2regions
-Angola;AGO;AFR;Middle East and Africa;Global South
-Benin;BEN;AFR;Middle East and Africa;Global South
-Botswana;BWA;AFR;Middle East and Africa;Global South
-British Indian Ocean Territory;IOT;AFR;Middle East and Africa;Global South
-Burkina Faso;BFA;AFR;Middle East and Africa;Global South
-Burundi;BDI;AFR;Middle East and Africa;Global South
-Cameroon;CMR;AFR;Middle East and Africa;Global South
-Cape Verde;CPV;AFR;Middle East and Africa;Global South
-Central African Republic;CAF;AFR;Middle East and Africa;Global South
-Chad;TCD;AFR;Middle East and Africa;Global South
-Comoros;COM;AFR;Middle East and Africa;Global South
-Cote d'Ivoire;CIV;AFR;Middle East and Africa;Global South
-Congo;COG;AFR;Middle East and Africa;Global South
-Djibouti;DJI;AFR;Middle East and Africa;Global South
-Equatorial Guinea;GNQ;AFR;Middle East and Africa;Global South
-Eritrea;ERI;AFR;Middle East and Africa;Global South
-Ethiopia;ETH;AFR;Middle East and Africa;Global South
-Gabon;GAB;AFR;Middle East and Africa;Global South
-Gambia;GMB;AFR;Middle East and Africa;Global South
-Ghana;GHA;AFR;Middle East and Africa;Global South
-Guinea;GIN;AFR;Middle East and Africa;Global South
-Guinea-Bissau;GNB;AFR;Middle East and Africa;Global South
-Kenya;KEN;AFR;Middle East and Africa;Global South
-Lesotho;LSO;AFR;Middle East and Africa;Global South
-Liberia;LBR;AFR;Middle East and Africa;Global South
-Madagascar;MDG;AFR;Middle East and Africa;Global South
-Malawi;MWI;AFR;Middle East and Africa;Global South
-Mali;MLI;AFR;Middle East and Africa;Global South
-Mauritania;MRT;AFR;Middle East and Africa;Global South
-Mauritius;MUS;AFR;Middle East and Africa;Global South
-Mozambique;MOZ;AFR;Middle East and Africa;Global South
-Namibia;NAM;AFR;Middle East and Africa;Global South
-Niger;NER;AFR;Middle East and Africa;Global South
-Nigeria;NGA;AFR;Middle East and Africa;Global South
-Reunion;REU;AFR;Middle East and Africa;Global South
-Rwanda;RWA;AFR;Middle East and Africa;Global South
-Sao Tome and Principe;STP;AFR;Middle East and Africa;Global South
-Senegal;SEN;AFR;Middle East and Africa;Global South
-Seychelles;SYC;AFR;Middle East and Africa;Global South
-Sierra Leone;SLE;AFR;Middle East and Africa;Global South
-Somalia;SOM;AFR;Middle East and Africa;Global South
-South Africa;ZAF;AFR;Middle East and Africa;Global South
-Saint Helena;SHN;AFR;Middle East and Africa;Global South
-Swaziland;SWZ;AFR;Middle East and Africa;Global South
-Tanzania;TZA;AFR;Middle East and Africa;Global South
-Togo;TGO;AFR;Middle East and Africa;Global South
-Uganda;UGA;AFR;Middle East and Africa;Global South
-Democratic Republic of the Congo;COD;AFR;Middle East and Africa;Global South
-Zambia;ZMB;AFR;Middle East and Africa;Global South
-Zimbabwe;ZWE;AFR;Middle East and Africa;Global South
-Cambodia;KHM;CPA;Asia;Global South
-China;CHN;CPA;Asia;Global South
-Korea (DPR);PRK;CPA;Asia;Global South
-Laos (PDR);LAO;CPA;Asia;Global South
-Mongolia;MNG;CPA;Asia;Global South
-Viet Nam;VNM;CPA;Asia;Global South
-Albania;ALB;EEU;Reforming Ecomonies;Global North
-Bosnia and Herzegovina;BIH;EEU;Reforming Ecomonies;Global North
-Bulgaria;BGR;EEU;Reforming Ecomonies;Global North
-Croatia;HRV;EEU;Reforming Ecomonies;Global North
-Czech Republic;CZE;EEU;Reforming Ecomonies;Global North
-Estonia;EST;EEU;Reforming Ecomonies;Global North
-The former Yugoslav Rep. of Macedonia;MKD;EEU;Reforming Ecomonies;Global North
-Latvia;LVA;EEU;Reforming Ecomonies;Global North
-Lithuania;LTU;EEU;Reforming Ecomonies;Global North
-Hungary;HUN;EEU;Reforming Ecomonies;Global North
-Poland;POL;EEU;Reforming Ecomonies;Global North
-Romania;ROU;EEU;Reforming Ecomonies;Global North
-Slovak Republic;SVK;EEU;Reforming Ecomonies;Global North
-Slovenia;SVN;EEU;Reforming Ecomonies;Global North
-Yugoslavia;YUG;EEU;Reforming Ecomonies;Global North
-Armenia;ARM;FSU;Reforming Ecomonies;Global North
-Azerbaijan;AZE;FSU;Reforming Ecomonies;Global North
-Belarus;BLR;FSU;Reforming Ecomonies;Global North
-Georgia;GEO;FSU;Reforming Ecomonies;Global North
-Kazakhstan;KAZ;FSU;Reforming Ecomonies;Global North
-Kyrgyzstan;KGZ;FSU;Reforming Ecomonies;Global North
-Republic of Moldova;MDA;FSU;Reforming Ecomonies;Global North
-Russian Federation;RUS;FSU;Reforming Ecomonies;Global North
-Tajikistan;TJK;FSU;Reforming Ecomonies;Global North
-Turkmenistan;TKM;FSU;Reforming Ecomonies;Global North
-Ukraine;UKR;FSU;Reforming Ecomonies;Global North
-Uzbekistan;UZB;FSU;Reforming Ecomonies;Global North
-Antigua and Barbuda;ATG;LAC;Latin America and the Caribbean;Global South
-Argentina;ARG;LAC;Latin America and the Caribbean;Global South
-Bahamas;BHS;LAC;Latin America and the Caribbean;Global South
-Barbados;BRB;LAC;Latin America and the Caribbean;Global South
-Belize;BLZ;LAC;Latin America and the Caribbean;Global South
-Bermuda;BMU;LAC;Latin America and the Caribbean;Global South
-Bolivia;BOL;LAC;Latin America and the Caribbean;Global South
-Brazil;BRA;LAC;Latin America and the Caribbean;Global South
-Chile;CHL;LAC;Latin America and the Caribbean;Global South
-Colombia;COL;LAC;Latin America and the Caribbean;Global South
-Costa Rica;CRI;LAC;Latin America and the Caribbean;Global South
-Cuba;CUB;LAC;Latin America and the Caribbean;Global South
-Dominica;DMA;LAC;Latin America and the Caribbean;Global South
-Dominican Republic;DOM;LAC;Latin America and the Caribbean;Global South
-Ecuador;ECU;LAC;Latin America and the Caribbean;Global South
-El Salvador;SLV;LAC;Latin America and the Caribbean;Global South
-French Guyana;GUF;LAC;Latin America and the Caribbean;Global South
-Grenada;GRD;LAC;Latin America and the Caribbean;Global South
-Guadeloupe;GLP;LAC;Latin America and the Caribbean;Global South
-Guatemala;GTM;LAC;Latin America and the Caribbean;Global South
-Guyana;GUY;LAC;Latin America and the Caribbean;Global South
-Haiti;HTI;LAC;Latin America and the Caribbean;Global South
-Honduras;HND;LAC;Latin America and the Caribbean;Global South
-Jamaica;JAM;LAC;Latin America and the Caribbean;Global South
-Martinique;MTQ;LAC;Latin America and the Caribbean;Global South
-Mexico;MEX;LAC;Latin America and the Caribbean;Global South
-Netherlands Antilles;ANT;LAC;Latin America and the Caribbean;Global South
-Nicaragua;NIC;LAC;Latin America and the Caribbean;Global South
-Panama;PAN;LAC;Latin America and the Caribbean;Global South
-Paraguay;PRY;LAC;Latin America and the Caribbean;Global South
-Peru;PER;LAC;Latin America and the Caribbean;Global South
-Saint Kitts and Nevis;KNA;LAC;Latin America and the Caribbean;Global South
-Santa Lucia;LCA;LAC;Latin America and the Caribbean;Global South
-Saint Vincent and the Grenadines;VCT;LAC;Latin America and the Caribbean;Global South
-Suriname;SUR;LAC;Latin America and the Caribbean;Global South
-Trinidad and Tobago;TTO;LAC;Latin America and the Caribbean;Global South
-Uruguay;URY;LAC;Latin America and the Caribbean;Global South
-Venezuela;VEN;LAC;Latin America and the Caribbean;Global South
-Algeria;DZA;MEA;Middle East and Africa;Global South
-Bahrain;BHR;MEA;Middle East and Africa;Global South
-Egypt (Arab Republic);EGY;MEA;Middle East and Africa;Global South
-Iraq;IRQ;MEA;Middle East and Africa;Global South
-Iran (Islamic Republic);IRN;MEA;Middle East and Africa;Global South
-Israel;ISR;MEA;Middle East and Africa;Global South
-Jordan;JOR;MEA;Middle East and Africa;Global South
-Kuwait;KWT;MEA;Middle East and Africa;Global South
-Lebanon;LBN;MEA;Middle East and Africa;Global South
-Libya/SPLAJ;LBY;MEA;Middle East and Africa;Global South
-Morocco;MAR;MEA;Middle East and Africa;Global South
-Oman;OMN;MEA;Middle East and Africa;Global South
-Qatar;QAT;MEA;Middle East and Africa;Global South
-Saudi Arabia;SAU;MEA;Middle East and Africa;Global South
-Sudan;SDN;MEA;Middle East and Africa;Global South
-Syria (Arab Republic);SYR;MEA;Middle East and Africa;Global South
-Tunisia;TUN;MEA;Middle East and Africa;Global South
-United Arab Emirates;ARE;MEA;Middle East and Africa;Global South
-Yemen;YEM;MEA;Middle East and Africa;Global South
-Canada;CAN;NAM;OECD 90;Global North
-Guam;GUM;NAM;OECD 90;Global North
-Puerto Rico;PRI;NAM;OECD 90;Global North
-United States of America;USA;NAM;OECD 90;Global North
-Virgin Islands, British;VGB;NAM;OECD 90;Global North
-Virgin Islands, U.S.;VIR;NAM;OECD 90;Global North
-Australia;AUS;PAO;OECD 90;Global North
-Japan;JPN;PAO;OECD 90;Global North
-New Zealand;NZL;PAO;OECD 90;Global North
-American Samoa;ASM;PAS;Asia;Global South
-Brunei Darussalam;BRN;PAS;Asia;Global South
-Fiji;FJI;PAS;Asia;Global South
-French Polynesia;PYF;PAS;Asia;Global South
-Gilbert-Kiribati;KIR;PAS;Asia;Global South
-Indonesia;IDN;PAS;Asia;Global South
-Malaysia;MYS;PAS;Asia;Global South
-Myanmar;MMR;PAS;Asia;Global South
-New Caledonia;NCL;PAS;Asia;Global South
-Papua New Guinea;PNG;PAS;Asia;Global South
-Philippines;PHL;PAS;Asia;Global South
-Republic of Korea;KOR;PAS;Asia;Global South
-Singapore;SGP;PAS;Asia;Global South
-Solomon Islands;SLB;PAS;Asia;Global South
-Taiwan (China);TWN;PAS;Asia;Global South
-Thailand;THA;PAS;Asia;Global South
-Tonga;TON;PAS;Asia;Global South
-Vanuatu;VUT;PAS;Asia;Global South
-Samoa;WSM;PAS;Asia;Global South
-Afghanistan;AFG;SAS;Asia;Global South
-Bangladesh;BGD;SAS;Asia;Global South
-Bhutan;BTN;SAS;Asia;Global South
-India;IND;SAS;Asia;Global South
-Maldives;MDV;SAS;Asia;Global South
-Nepal;NPL;SAS;Asia;Global South
-Pakistan;PAK;SAS;Asia;Global South
-Sri Lanka;LKA;SAS;Asia;Global South
-Andorra;AND;WEU;OECD 90;Global North
-Austria;AUT;WEU;OECD 90;Global North
-Belgium;BEL;WEU;OECD 90;Global North
-Jersey;JEY;WEU;OECD 90;Global North
-Guernsey;GGY;WEU;OECD 90;Global North
-Cyprus;CYP;WEU;OECD 90;Global North
-Denmark;DNK;WEU;OECD 90;Global North
-Faeroe Islands;FRO;WEU;OECD 90;Global North
-Finland;FIN;WEU;OECD 90;Global North
-France;FRA;WEU;OECD 90;Global North
-Germany;DEU;WEU;OECD 90;Global North
-Gibraltar;GIB;WEU;OECD 90;Global North
-Greece;GRC;WEU;OECD 90;Global North
-Greenland;GRL;WEU;OECD 90;Global North
-Iceland;ISL;WEU;OECD 90;Global North
-Ireland;IRL;WEU;OECD 90;Global North
-Isle of Man;IMN;WEU;OECD 90;Global North
-Italy;ITA;WEU;OECD 90;Global North
-Liechtenstein;LIE;WEU;OECD 90;Global North
-Luxembourg;LUX;WEU;OECD 90;Global North
-Malta;MLT;WEU;OECD 90;Global North
-Monaco;MCO;WEU;OECD 90;Global North
-Netherlands;NLD;WEU;OECD 90;Global North
-Norway;NOR;WEU;OECD 90;Global North
-Portugal;PRT;WEU;OECD 90;Global North
-Spain;ESP;WEU;OECD 90;Global North
-Sweden;SWE;WEU;OECD 90;Global North
-Switzerland;CHE;WEU;OECD 90;Global North
-Turkey;TUR;WEU;OECD 90;Global North
-United Kingdom;GBR;WEU;OECD 90;Global North
-Aland�Islands;ALA;WEU;OECD 90;Global North
-Anguilla;AIA;LAC;Latin America and the Caribbean;Global South
-Antarctica;ATA;LAC;Latin America and the Caribbean;Global South
-Aruba;ABW;LAC;Latin America and the Caribbean;Global South
-Bonaire,�Sint�Eustatius�and�Saba;BES;LAC;Latin America and the Caribbean;Global South
-Bouvet�Island;BVT;LAC;Latin America and the Caribbean;Global South
-Cayman�Islands;CYM;LAC;Latin America and the Caribbean;Global South
-Christmas�Island;CXR;PAO;OECD 90;Global North
-Cocos�(Keeling)�Islands;CCK;PAO;OECD 90;Global North
-Cook�Islands;COK;PAO;OECD 90;Global North
-Curacao;CUW;LAC;Latin America and the Caribbean;Global South
-Falkland�Islands�(Malvinas);FLK;LAC;Latin America and the Caribbean;Global South
-French�Southern�Territories;ATF;LAC;Latin America and the Caribbean;Global South
-Heard�Island�and�McDonald�Islands;HMD;PAO;OECD 90;Global North
-Holy�See�(Vatican�City�State);VAT;WEU;OECD 90;Global North
-Hong�Kong;HKG;CPA;Asia;Global South
-Macao;MAC;CPA;Asia;Global South
-Marshall�Islands;MHL;PAS;Asia;Global South
-Mayotte;MYT;AFR;Middle East and Africa;Global South
-Micronesia,�Federated�States�of;FSM;PAS;Asia;Global South
-Montenegro;MNE;EEU;Reforming Ecomonies;Global North
-Montserrat;MSR;LAC;Latin America and the Caribbean;Global South
-Nauru;NRU;PAS;Asia;Global South
-Niue;NIU;PAO;OECD 90;Global North
-Norfolk�Island;NFK;PAO;OECD 90;Global North
-Northern�Mariana�Islands;MNP;PAS;Asia;Global South
-Palau;PLW;PAS;Asia;Global South
-Palestine,�State�of;PSE;MEA;Middle East and Africa;Global South
-Pitcairn;PCN;PAS;Asia;Global South
-Saint�Barthelemy;BLM;LAC;Latin America and the Caribbean;Global South
-Saint�Martin�(French�part);MAF;LAC;Latin America and the Caribbean;Global South
-Saint�Pierre�and�Miquelon;SPM;NAM;OECD 90;Global North
-San�Marino;SMR;WEU;OECD 90;Global North
-Serbia;SRB;WEU;OECD 90;Global North
-Sint�Maarten�(Dutch�part);SXM;LAC;Latin America and the Caribbean;Global South
-South�Georgia�and�the�South�Sandwich�Islands;SGS;LAC;Latin America and the Caribbean;Global South
-South�Sudan;SSD;AFR;Middle East and Africa;Global South
-Svalbard�and�Jan�Mayen;SJM;WEU;OECD 90;Global North
-Timor-Leste;TLS;PAS;Asia;Global South
-Tokelau;TKL;PAS;Asia;Global South
-Turks�and�Caicos�Islands;TCA;LAC;Latin America and the Caribbean;Global South
-Tuvalu;TUV;PAS;Asia;Global South
-United�States�Minor�Outlying�Islands;UMI;PAS;Asia;Global South
-Wallis�and�Futuna;WLF;PAS;Asia;Global South
-Western�Sahara;ESH;MEA;Middle East and Africa;Global South
+X;CountryCode;R12;11regions;5regions;2regions
+Angola;AGO;AFR;AFR;Middle East and Africa;Global South
+Benin;BEN;AFR;AFR;Middle East and Africa;Global South
+Botswana;BWA;AFR;AFR;Middle East and Africa;Global South
+British Indian Ocean Territory;IOT;AFR;AFR;Middle East and Africa;Global South
+Burkina Faso;BFA;AFR;AFR;Middle East and Africa;Global South
+Burundi;BDI;AFR;AFR;Middle East and Africa;Global South
+Cameroon;CMR;AFR;AFR;Middle East and Africa;Global South
+Cape Verde;CPV;AFR;AFR;Middle East and Africa;Global South
+Central African Republic;CAF;AFR;AFR;Middle East and Africa;Global South
+Chad;TCD;AFR;AFR;Middle East and Africa;Global South
+Comoros;COM;AFR;AFR;Middle East and Africa;Global South
+Cote d'Ivoire;CIV;AFR;AFR;Middle East and Africa;Global South
+Congo;COG;AFR;AFR;Middle East and Africa;Global South
+Djibouti;DJI;AFR;AFR;Middle East and Africa;Global South
+Equatorial Guinea;GNQ;AFR;AFR;Middle East and Africa;Global South
+Eritrea;ERI;AFR;AFR;Middle East and Africa;Global South
+Ethiopia;ETH;AFR;AFR;Middle East and Africa;Global South
+Gabon;GAB;AFR;AFR;Middle East and Africa;Global South
+Gambia;GMB;AFR;AFR;Middle East and Africa;Global South
+Ghana;GHA;AFR;AFR;Middle East and Africa;Global South
+Guinea;GIN;AFR;AFR;Middle East and Africa;Global South
+Guinea-Bissau;GNB;AFR;AFR;Middle East and Africa;Global South
+Kenya;KEN;AFR;AFR;Middle East and Africa;Global South
+Lesotho;LSO;AFR;AFR;Middle East and Africa;Global South
+Liberia;LBR;AFR;AFR;Middle East and Africa;Global South
+Madagascar;MDG;AFR;AFR;Middle East and Africa;Global South
+Malawi;MWI;AFR;AFR;Middle East and Africa;Global South
+Mali;MLI;AFR;AFR;Middle East and Africa;Global South
+Mauritania;MRT;AFR;AFR;Middle East and Africa;Global South
+Mauritius;MUS;AFR;AFR;Middle East and Africa;Global South
+Mozambique;MOZ;AFR;AFR;Middle East and Africa;Global South
+Namibia;NAM;AFR;AFR;Middle East and Africa;Global South
+Niger;NER;AFR;AFR;Middle East and Africa;Global South
+Nigeria;NGA;AFR;AFR;Middle East and Africa;Global South
+Reunion;REU;AFR;AFR;Middle East and Africa;Global South
+Rwanda;RWA;AFR;AFR;Middle East and Africa;Global South
+Sao Tome and Principe;STP;AFR;AFR;Middle East and Africa;Global South
+Senegal;SEN;AFR;AFR;Middle East and Africa;Global South
+Seychelles;SYC;AFR;AFR;Middle East and Africa;Global South
+Sierra Leone;SLE;AFR;AFR;Middle East and Africa;Global South
+Somalia;SOM;AFR;AFR;Middle East and Africa;Global South
+South Africa;ZAF;AFR;AFR;Middle East and Africa;Global South
+Saint Helena;SHN;AFR;AFR;Middle East and Africa;Global South
+Swaziland;SWZ;AFR;AFR;Middle East and Africa;Global South
+Tanzania;TZA;AFR;AFR;Middle East and Africa;Global South
+Togo;TGO;AFR;AFR;Middle East and Africa;Global South
+Uganda;UGA;AFR;AFR;Middle East and Africa;Global South
+Democratic Republic of the Congo;COD;AFR;AFR;Middle East and Africa;Global South
+Zambia;ZMB;AFR;AFR;Middle East and Africa;Global South
+Zimbabwe;ZWE;AFR;AFR;Middle East and Africa;Global South
+Cambodia;KHM;RCPA;CPA;Asia;Global South
+China;CHN;CHN;CPA;Asia;Global South
+Korea (DPR);PRK;RCPA;CPA;Asia;Global South
+Laos (PDR);LAO;RCPA;CPA;Asia;Global South
+Mongolia;MNG;RCPA;CPA;Asia;Global South
+Viet Nam;VNM;RCPA;CPA;Asia;Global South
+Albania;ALB;EEU;EEU;Reforming Ecomonies;Global North
+Bosnia and Herzegovina;BIH;EEU;EEU;Reforming Ecomonies;Global North
+Bulgaria;BGR;EEU;EEU;Reforming Ecomonies;Global North
+Croatia;HRV;EEU;EEU;Reforming Ecomonies;Global North
+Czech Republic;CZE;EEU;EEU;Reforming Ecomonies;Global North
+Estonia;EST;EEU;EEU;Reforming Ecomonies;Global North
+The former Yugoslav Rep. of Macedonia;MKD;EEU;EEU;Reforming Ecomonies;Global North
+Latvia;LVA;EEU;EEU;Reforming Ecomonies;Global North
+Lithuania;LTU;EEU;EEU;Reforming Ecomonies;Global North
+Hungary;HUN;EEU;EEU;Reforming Ecomonies;Global North
+Poland;POL;EEU;EEU;Reforming Ecomonies;Global North
+Romania;ROU;EEU;EEU;Reforming Ecomonies;Global North
+Slovak Republic;SVK;EEU;EEU;Reforming Ecomonies;Global North
+Slovenia;SVN;EEU;EEU;Reforming Ecomonies;Global North
+Yugoslavia;YUG;EEU;EEU;Reforming Ecomonies;Global North
+Armenia;ARM;FSU;FSU;Reforming Ecomonies;Global North
+Azerbaijan;AZE;FSU;FSU;Reforming Ecomonies;Global North
+Belarus;BLR;FSU;FSU;Reforming Ecomonies;Global North
+Georgia;GEO;FSU;FSU;Reforming Ecomonies;Global North
+Kazakhstan;KAZ;FSU;FSU;Reforming Ecomonies;Global North
+Kyrgyzstan;KGZ;FSU;FSU;Reforming Ecomonies;Global North
+Republic of Moldova;MDA;FSU;FSU;Reforming Ecomonies;Global North
+Russian Federation;RUS;FSU;FSU;Reforming Ecomonies;Global North
+Tajikistan;TJK;FSU;FSU;Reforming Ecomonies;Global North
+Turkmenistan;TKM;FSU;FSU;Reforming Ecomonies;Global North
+Ukraine;UKR;FSU;FSU;Reforming Ecomonies;Global North
+Uzbekistan;UZB;FSU;FSU;Reforming Ecomonies;Global North
+Antigua and Barbuda;ATG;LAM;LAC;Latin America and the Caribbean;Global South
+Argentina;ARG;LAM;LAC;Latin America and the Caribbean;Global South
+Bahamas;BHS;LAM;LAC;Latin America and the Caribbean;Global South
+Barbados;BRB;LAM;LAC;Latin America and the Caribbean;Global South
+Belize;BLZ;LAM;LAC;Latin America and the Caribbean;Global South
+Bermuda;BMU;LAM;LAC;Latin America and the Caribbean;Global South
+Bolivia;BOL;LAM;LAC;Latin America and the Caribbean;Global South
+Brazil;BRA;LAM;LAC;Latin America and the Caribbean;Global South
+Chile;CHL;LAM;LAC;Latin America and the Caribbean;Global South
+Colombia;COL;LAM;LAC;Latin America and the Caribbean;Global South
+Costa Rica;CRI;LAM;LAC;Latin America and the Caribbean;Global South
+Cuba;CUB;LAM;LAC;Latin America and the Caribbean;Global South
+Dominica;DMA;LAM;LAC;Latin America and the Caribbean;Global South
+Dominican Republic;DOM;LAM;LAC;Latin America and the Caribbean;Global South
+Ecuador;ECU;LAM;LAC;Latin America and the Caribbean;Global South
+El Salvador;SLV;LAM;LAC;Latin America and the Caribbean;Global South
+French Guyana;GUF;LAM;LAC;Latin America and the Caribbean;Global South
+Grenada;GRD;LAM;LAC;Latin America and the Caribbean;Global South
+Guadeloupe;GLP;LAM;LAC;Latin America and the Caribbean;Global South
+Guatemala;GTM;LAM;LAC;Latin America and the Caribbean;Global South
+Guyana;GUY;LAM;LAC;Latin America and the Caribbean;Global South
+Haiti;HTI;LAM;LAC;Latin America and the Caribbean;Global South
+Honduras;HND;LAM;LAC;Latin America and the Caribbean;Global South
+Jamaica;JAM;LAM;LAC;Latin America and the Caribbean;Global South
+Martinique;MTQ;LAM;LAC;Latin America and the Caribbean;Global South
+Mexico;MEX;LAM;LAC;Latin America and the Caribbean;Global South
+Netherlands Antilles;ANT;LAM;LAC;Latin America and the Caribbean;Global South
+Nicaragua;NIC;LAM;LAC;Latin America and the Caribbean;Global South
+Panama;PAN;LAM;LAC;Latin America and the Caribbean;Global South
+Paraguay;PRY;LAM;LAC;Latin America and the Caribbean;Global South
+Peru;PER;LAM;LAC;Latin America and the Caribbean;Global South
+Saint Kitts and Nevis;KNA;LAM;LAC;Latin America and the Caribbean;Global South
+Santa Lucia;LCA;LAM;LAC;Latin America and the Caribbean;Global South
+Saint Vincent and the Grenadines;VCT;LAM;LAC;Latin America and the Caribbean;Global South
+Suriname;SUR;LAM;LAC;Latin America and the Caribbean;Global South
+Trinidad and Tobago;TTO;LAM;LAC;Latin America and the Caribbean;Global South
+Uruguay;URY;LAM;LAC;Latin America and the Caribbean;Global South
+Venezuela;VEN;LAM;LAC;Latin America and the Caribbean;Global South
+Algeria;DZA;MEA;MEA;Middle East and Africa;Global South
+Bahrain;BHR;MEA;MEA;Middle East and Africa;Global South
+Egypt (Arab Republic);EGY;MEA;MEA;Middle East and Africa;Global South
+Iraq;IRQ;MEA;MEA;Middle East and Africa;Global South
+Iran (Islamic Republic);IRN;MEA;MEA;Middle East and Africa;Global South
+Israel;ISR;MEA;MEA;Middle East and Africa;Global South
+Jordan;JOR;MEA;MEA;Middle East and Africa;Global South
+Kuwait;KWT;MEA;MEA;Middle East and Africa;Global South
+Lebanon;LBN;MEA;MEA;Middle East and Africa;Global South
+Libya/SPLAJ;LBY;MEA;MEA;Middle East and Africa;Global South
+Morocco;MAR;MEA;MEA;Middle East and Africa;Global South
+Oman;OMN;MEA;MEA;Middle East and Africa;Global South
+Qatar;QAT;MEA;MEA;Middle East and Africa;Global South
+Saudi Arabia;SAU;MEA;MEA;Middle East and Africa;Global South
+Sudan;SDN;MEA;MEA;Middle East and Africa;Global South
+Syria (Arab Republic);SYR;MEA;MEA;Middle East and Africa;Global South
+Tunisia;TUN;MEA;MEA;Middle East and Africa;Global South
+United Arab Emirates;ARE;MEA;MEA;Middle East and Africa;Global South
+Yemen;YEM;MEA;MEA;Middle East and Africa;Global South
+Canada;CAN;NAM;NAM;OECD 90;Global North
+Guam;GUM;NAM;NAM;OECD 90;Global North
+Puerto Rico;PRI;NAM;NAM;OECD 90;Global North
+United States of America;USA;NAM;NAM;OECD 90;Global North
+Virgin Islands, British;VGB;NAM;NAM;OECD 90;Global North
+Virgin Islands, U.S.;VIR;NAM;NAM;OECD 90;Global North
+Australia;AUS;PAO;PAO;OECD 90;Global North
+Japan;JPN;PAO;PAO;OECD 90;Global North
+New Zealand;NZL;PAO;PAO;OECD 90;Global North
+American Samoa;ASM;PAS;PAS;Asia;Global South
+Brunei Darussalam;BRN;PAS;PAS;Asia;Global South
+Fiji;FJI;PAS;PAS;Asia;Global South
+French Polynesia;PYF;PAS;PAS;Asia;Global South
+Gilbert-Kiribati;KIR;PAS;PAS;Asia;Global South
+Indonesia;IDN;PAS;PAS;Asia;Global South
+Malaysia;MYS;PAS;PAS;Asia;Global South
+Myanmar;MMR;PAS;PAS;Asia;Global South
+New Caledonia;NCL;PAS;PAS;Asia;Global South
+Papua New Guinea;PNG;PAS;PAS;Asia;Global South
+Philippines;PHL;PAS;PAS;Asia;Global South
+Republic of Korea;KOR;PAS;PAS;Asia;Global South
+Singapore;SGP;PAS;PAS;Asia;Global South
+Solomon Islands;SLB;PAS;PAS;Asia;Global South
+Taiwan (China);TWN;PAS;PAS;Asia;Global South
+Thailand;THA;PAS;PAS;Asia;Global South
+Tonga;TON;PAS;PAS;Asia;Global South
+Vanuatu;VUT;PAS;PAS;Asia;Global South
+Samoa;WSM;PAS;PAS;Asia;Global South
+Afghanistan;AFG;SAS;SAS;Asia;Global South
+Bangladesh;BGD;SAS;SAS;Asia;Global South
+Bhutan;BTN;SAS;SAS;Asia;Global South
+India;IND;SAS;SAS;Asia;Global South
+Maldives;MDV;SAS;SAS;Asia;Global South
+Nepal;NPL;SAS;SAS;Asia;Global South
+Pakistan;PAK;SAS;SAS;Asia;Global South
+Sri Lanka;LKA;SAS;SAS;Asia;Global South
+Andorra;AND;WEU;WEU;OECD 90;Global North
+Austria;AUT;WEU;WEU;OECD 90;Global North
+Belgium;BEL;WEU;WEU;OECD 90;Global North
+Jersey;JEY;WEU;WEU;OECD 90;Global North
+Guernsey;GGY;WEU;WEU;OECD 90;Global North
+Cyprus;CYP;WEU;WEU;OECD 90;Global North
+Denmark;DNK;WEU;WEU;OECD 90;Global North
+Faeroe Islands;FRO;WEU;WEU;OECD 90;Global North
+Finland;FIN;WEU;WEU;OECD 90;Global North
+France;FRA;WEU;WEU;OECD 90;Global North
+Germany;DEU;WEU;WEU;OECD 90;Global North
+Gibraltar;GIB;WEU;WEU;OECD 90;Global North
+Greece;GRC;WEU;WEU;OECD 90;Global North
+Greenland;GRL;WEU;WEU;OECD 90;Global North
+Iceland;ISL;WEU;WEU;OECD 90;Global North
+Ireland;IRL;WEU;WEU;OECD 90;Global North
+Isle of Man;IMN;WEU;WEU;OECD 90;Global North
+Italy;ITA;WEU;WEU;OECD 90;Global North
+Liechtenstein;LIE;WEU;WEU;OECD 90;Global North
+Luxembourg;LUX;WEU;WEU;OECD 90;Global North
+Malta;MLT;WEU;WEU;OECD 90;Global North
+Monaco;MCO;WEU;WEU;OECD 90;Global North
+Netherlands;NLD;WEU;WEU;OECD 90;Global North
+Norway;NOR;WEU;WEU;OECD 90;Global North
+Portugal;PRT;WEU;WEU;OECD 90;Global North
+Spain;ESP;WEU;WEU;OECD 90;Global North
+Sweden;SWE;WEU;WEU;OECD 90;Global North
+Switzerland;CHE;WEU;WEU;OECD 90;Global North
+Turkey;TUR;WEU;WEU;OECD 90;Global North
+United Kingdom;GBR;WEU;WEU;OECD 90;Global North
+Aland�Islands;ALA;WEU;WEU;OECD 90;Global North
+Anguilla;AIA;LAM;LAC;Latin America and the Caribbean;Global South
+Antarctica;ATA;LAM;LAC;Latin America and the Caribbean;Global South
+Aruba;ABW;LAM;LAC;Latin America and the Caribbean;Global South
+Bonaire,�Sint�Eustatius�and�Saba;BES;LAM;LAC;Latin America and the Caribbean;Global South
+Bouvet�Island;BVT;LAM;LAC;Latin America and the Caribbean;Global South
+Cayman�Islands;CYM;LAM;LAC;Latin America and the Caribbean;Global South
+Christmas�Island;CXR;PAO;PAO;OECD 90;Global North
+Cocos�(Keeling)�Islands;CCK;PAO;PAO;OECD 90;Global North
+Cook�Islands;COK;PAO;PAO;OECD 90;Global North
+Curacao;CUW;LAM;LAC;Latin America and the Caribbean;Global South
+Falkland�Islands�(Malvinas);FLK;LAM;LAC;Latin America and the Caribbean;Global South
+French�Southern�Territories;ATF;LAM;LAC;Latin America and the Caribbean;Global South
+Heard�Island�and�McDonald�Islands;HMD;PAO;PAO;OECD 90;Global North
+Holy�See�(Vatican�City�State);VAT;WEU;WEU;OECD 90;Global North
+Hong�Kong;HKG;CHN;CPA;Asia;Global South
+Macao;MAC;CHN;CPA;Asia;Global South
+Marshall�Islands;MHL;PAS;PAS;Asia;Global South
+Mayotte;MYT;AFR;AFR;Middle East and Africa;Global South
+Micronesia,�Federated�States�of;FSM;PAS;PAS;Asia;Global South
+Montenegro;MNE;EEU;EEU;Reforming Ecomonies;Global North
+Montserrat;MSR;LAM;LAC;Latin America and the Caribbean;Global South
+Nauru;NRU;PAS;PAS;Asia;Global South
+Niue;NIU;PAO;PAO;OECD 90;Global North
+Norfolk�Island;NFK;PAO;PAO;OECD 90;Global North
+Northern�Mariana�Islands;MNP;PAS;PAS;Asia;Global South
+Palau;PLW;PAS;PAS;Asia;Global South
+Palestine,�State�of;PSE;MEA;MEA;Middle East and Africa;Global South
+Pitcairn;PCN;PAS;PAS;Asia;Global South
+Saint�Barthelemy;BLM;LAM;LAC;Latin America and the Caribbean;Global South
+Saint�Martin�(French�part);MAF;LAM;LAC;Latin America and the Caribbean;Global South
+Saint�Pierre�and�Miquelon;SPM;NAM;NAM;OECD 90;Global North
+San�Marino;SMR;WEU;WEU;OECD 90;Global North
+Serbia;SRB;WEU;WEU;OECD 90;Global North
+Sint�Maarten�(Dutch�part);SXM;LAM;LAC;Latin America and the Caribbean;Global South
+South�Georgia�and�the�South�Sandwich�Islands;SGS;LAM;LAC;Latin America and the Caribbean;Global South
+South�Sudan;SSD;AFR;AFR;Middle East and Africa;Global South
+Svalbard�and�Jan�Mayen;SJM;WEU;WEU;OECD 90;Global North
+Timor-Leste;TLS;PAS;PAS;Asia;Global South
+Tokelau;TKL;PAS;PAS;Asia;Global South
+Turks�and�Caicos�Islands;TCA;LAM;LAC;Latin America and the Caribbean;Global South
+Tuvalu;TUV;PAS;PAS;Asia;Global South
+United�States�Minor�Outlying�Islands;UMI;PAS;PAS;Asia;Global South
+Wallis�and�Futuna;WLF;PAS;PAS;Asia;Global South
+Western�Sahara;ESH;MEA;MEA;Middle East and Africa;Global South

--- a/inst/extdata/sectoral/variableMapping_ICT.csv
+++ b/inst/extdata/sectoral/variableMapping_ICT.csv
@@ -1,15 +1,15 @@
 variable,variableTarget
-dc lower bound,dc lower
-dc upper bound,dc upper
+dc lower bound,dc low
+dc upper bound,dc high
 dc mean,dc mean
-dc central estimate,dc central
-lower bound dc,dc lower
-upper bound dc,dc upper
+dc central estimate,dc medium
+lower bound dc,dc low
+upper bound dc,dc high
 mean dc,dc mean
-central estimate dc,dc central
-ict lower,ict lower
-ict upper,ict upper
+central estimate dc,dc medium
+ict lower,ict low
+ict upper,ict high
 mean,ict mean
-central estimate,ict central
-lower ict,ict lower
-upper ict,ict upper
+central estimate,ict medium
+lower ict,ict low
+upper ict,ict high

--- a/man/calcElecDemandICT.Rd
+++ b/man/calcElecDemandICT.Rd
@@ -4,13 +4,10 @@
 \alias{calcElecDemandICT}
 \title{Calculate Electricity Demand for ICT from Data Center Demands}
 \usage{
-calcElecDemandICT(endOfHistory = 2025, extrapolate = FALSE)
+calcElecDemandICT(endOfHistory = 2025)
 }
 \arguments{
 \item{endOfHistory}{upper temporal boundary for historical data}
-
-\item{extrapolate}{if \code{TRUE}, regional demand will be linearly extrapolated using the slope
-of the last two existing data points per scenario, if \code{FALSE} data remains unchanged}
 }
 \value{
 A magpie object containing ICT electricity demand data calculated from

--- a/man/calcElecDemandICT.Rd
+++ b/man/calcElecDemandICT.Rd
@@ -22,14 +22,15 @@ as the primary driver of demand, with IEA data serving as the historical baselin
 \details{
 The function processes multiple demand estimates:
 \itemize{
-\item Mean and central estimate
+\item Mean and medium estimate
 \item Lower demand boundary (DGI elasticity from historical efficiency dominant phases)
 \item Upper demand boundary (DGI elasticity from historical service dominant phases)
 }
 
-Data is downscaled from R5 to country-level using historical DC counts,
-with fixed network shares calculated at the end of the historical period. Historical
-data (IEA Base) is separated and harmonized with SSP scenario projections.
+Data is downscaled from R5 to country-level using data center counts as weights,
+with exceptional fixed shares for China within Asia Pacific (73.28\%) and for Europe's
+R12 sub-regions (WEU: 75\%, EEU: 14\%, FSU: 11\%). Network demand is added using global network/DC ratios.
+Historical data (IEA Base) is separated and harmonized with SSP scenario projections.
 }
 \author{
 Hagen Tockhorn

--- a/man/readPRISMA_ICT.Rd
+++ b/man/readPRISMA_ICT.Rd
@@ -8,7 +8,7 @@ readPRISMA_ICT(subtype)
 }
 \arguments{
 \item{subtype}{Character string specifying data type: "R12" for 12-region ICT data,
-"R5" for 5-region data center data, or "nDC" for data center counts}
+"R5" for 5-region data center data ("R5 2100" until 2100), or "nDC" for data center counts}
 }
 \value{
 A magpie object containing the requested ICT/data center data

--- a/man/readPRISMA_ICT.Rd
+++ b/man/readPRISMA_ICT.Rd
@@ -7,8 +7,7 @@
 readPRISMA_ICT(subtype)
 }
 \arguments{
-\item{subtype}{Character string specifying data type: "R12" for 12-region ICT data,
-"R5" for 5-region data center data ("R5 2100" until 2100), or "nDC" for data center counts}
+\item{subtype}{Character string specifying data type}
 }
 \value{
 A magpie object containing the requested ICT/data center data


### PR DESCRIPTION
Within the PRISMA project, new data centre electricity demand projections were shared up until 2100. This makes our `extrapolate` option obsolete. Even though we might not use the projections later on (or outside of the PRISMA project) in EDGE-B, it's nice to have a full data set generated from a consistent set of drivers. 
I also changed the demand estimate nomenclature to `low`/`medium`/`high`.

I also removed the aggregation weights. I don't know why I did that in the past since it's an extensive quantity. This previously caused that the total demands would not line up with the source data - this is now luckily corrected.